### PR TITLE
hack: insert content rendering for content pages at build time and remove inline rendering from markdown files

### DIFF
--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -53,6 +53,17 @@ module.exports = function (eleventyConfig) {
     interval: 500,
   });
 
+  // HACK: #39 This is dumb and janky, but it works for now. We need to move the content out of the frontmatter an into the content of the markdown file.
+  eleventyConfig.addCollection("contentpages", function(collectionApi) {
+    const insertcode = `{% from "widgets/text.njk" import renderContent %} {{renderContent(content)}}`;
+    return collectionApi.getFilteredByTag("contentpages").map(page => {
+      if (!page.template.frontMatter.content.includes(insertcode)) {
+        page.template.frontMatter.content += insertcode;
+      }
+      return page;
+    });
+  });
+
   return {
     dir: {
       input: "src",

--- a/src/pages/commercial.md
+++ b/src/pages/commercial.md
@@ -120,6 +120,3 @@ content:
 tags:
   - contentpages
 ---
-
-{% from "widgets/text.njk" import renderContent %}
-{{renderContent(content)}}

--- a/src/pages/residential.md
+++ b/src/pages/residential.md
@@ -246,5 +246,4 @@ tags:
   - contentpages
 ---
 
-{% from "widgets/text.njk" import renderContent %}
-{{renderContent(content)}}
+

--- a/src/pages/tower-services.md
+++ b/src/pages/tower-services.md
@@ -31,6 +31,3 @@ content:
 tags:
   - contentpages
 ---
-
-{% from "widgets/text.njk" import renderContent %}
-{{renderContent(content)}}


### PR DESCRIPTION
This is a bad solution, but it at least is a solution